### PR TITLE
Update amazon.aws module path in ansible v2.10

### DIFF
--- a/library/ec2_eip_facts.py
+++ b/library/ec2_eip_facts.py
@@ -75,8 +75,8 @@ addresses:
 
 '''
 
-from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import (ansible_dict_to_boto3_filter_list,
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (ansible_dict_to_boto3_filter_list,
                                       boto3_tag_list_to_ansible_dict,
                                       camel_dict_to_snake_dict)
 try:


### PR DESCRIPTION
In order to support ansible v2.10.
Plan to release v1.0.0